### PR TITLE
[Feat/#5] swagger 설정 및 대시보드, 나의 뱃지 관리 페이지 get 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.2.5'
+    // swagger 버전 문제 때문에 스프링부트 버전 낮춤
+	// id 'org.springframework.boot' version '3.5.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -26,17 +28,17 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	// testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//swagger
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	// testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//swagger
+    //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 

--- a/src/main/java/com/veribadge/veribadge/config/SwaggerConfig.java
+++ b/src/main/java/com/veribadge/veribadge/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.veribadge.veribadge.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+public class SwaggerConfig {
+    // http://localhost:8080/swagger-ui/index.html
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("VeriBadge API")
+                        .description("베리뱃지 프로젝트의 REST API 명세서입니다.")
+                        .version("v1.0.0")
+                        .contact(new Contact()
+                                .name("VeriBadge Team")
+                                .email("ysnoh0455@gmail.com"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("http://www.apache.org/licenses/LICENSE-2.0")));
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/controller/MainController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/MainController.java
@@ -1,0 +1,26 @@
+package com.veribadge.veribadge.controller;
+
+import com.veribadge.veribadge.dto.DashboardResponseDto;
+import com.veribadge.veribadge.exception.Response;
+import com.veribadge.veribadge.global.status.SuccessStatus;
+import com.veribadge.veribadge.service.MainService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "대시보드", description = "메인 페이지 API")
+@RequiredArgsConstructor
+public class MainController {
+
+    private final MainService mainService;
+
+    @Operation(summary = "나의 뱃지 관리 조회")
+    @GetMapping
+    public Response<DashboardResponseDto> getMyBadge(){
+        DashboardResponseDto dto = mainService.getMyBadge();
+        return Response.success(SuccessStatus.MEMBER_CREATED, dto);
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/controller/MainController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/MainController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,8 +20,8 @@ public class MainController {
 
     @Operation(summary = "나의 뱃지 관리 조회")
     @GetMapping
-    public Response<DashboardResponseDto> getMyBadge(){
-        DashboardResponseDto dto = mainService.getMyBadge();
-        return Response.success(SuccessStatus.MEMBER_CREATED, dto);
+    public Response<DashboardResponseDto> getMyBadge(@RequestParam("userId") Long userId){
+        DashboardResponseDto dto = mainService.getMyBadge(userId);
+        return Response.success(SuccessStatus.MAIN_SUCCESS, dto);
     }
 }

--- a/src/main/java/com/veribadge/veribadge/controller/MyBadgeController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/MyBadgeController.java
@@ -1,0 +1,36 @@
+package com.veribadge.veribadge.controller;
+
+import com.veribadge.veribadge.dto.MyBadgeResponseDto;
+import com.veribadge.veribadge.exception.Response;
+import com.veribadge.veribadge.global.status.SuccessStatus;
+import com.veribadge.veribadge.service.MyBadgeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("my-badge")
+@Tag(name = "나의 뱃지 관리", description = "나의 뱃지 관리 API")
+@RequiredArgsConstructor
+public class MyBadgeController {
+
+    private final MyBadgeService myBadgeService;
+
+    @Operation(summary = "나의 뱃지 관리 조회")
+    @GetMapping
+    public Response<MyBadgeResponseDto> getMyBadge(){
+        MyBadgeResponseDto dto = myBadgeService.getMyBadge();
+        return Response.success(SuccessStatus.MY_BADGE_SUCCESS, dto);
+    }
+
+    @Operation(summary = "Youtube 채널 연결")
+    @PostMapping("/connect-url")
+    public Response<Object> connectChannel(){
+
+        return Response.success(SuccessStatus.SUCCESS, null); // Todo : 성공 상태 변경
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/controller/MyBadgeController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/MyBadgeController.java
@@ -7,10 +7,7 @@ import com.veribadge.veribadge.service.MyBadgeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("my-badge")
@@ -22,15 +19,15 @@ public class MyBadgeController {
 
     @Operation(summary = "나의 뱃지 관리 조회")
     @GetMapping
-    public Response<MyBadgeResponseDto> getMyBadge(){
-        MyBadgeResponseDto dto = myBadgeService.getMyBadge();
+    public Response<MyBadgeResponseDto> getMyBadge(@RequestParam("userId") Long userId){
+        MyBadgeResponseDto dto = myBadgeService.getMyBadge(userId);
         return Response.success(SuccessStatus.MY_BADGE_SUCCESS, dto);
     }
 
-    @Operation(summary = "Youtube 채널 연결")
-    @PostMapping("/connect-url")
-    public Response<Object> connectChannel(){
-
-        return Response.success(SuccessStatus.SUCCESS, null); // Todo : 성공 상태 변경
-    }
+//    @Operation(summary = "Youtube 채널 연결")
+//    @PostMapping("/connect-url")
+//    public Response<Object> connectChannel(){
+//
+//        return Response.success(SuccessStatus.SUCCESS, null); // Todo : 성공 상태 변경
+//    }
 }

--- a/src/main/java/com/veribadge/veribadge/dto/DashboardResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/DashboardResponseDto.java
@@ -1,5 +1,6 @@
 package com.veribadge.veribadge.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.veribadge.veribadge.domain.enums.BadgeLevel;
 import com.veribadge.veribadge.domain.enums.Role;
 import com.veribadge.veribadge.domain.enums.VerificationStatus;
@@ -18,6 +19,8 @@ public class DashboardResponseDto {
 
     // 뱃지 발급받은 경우만
     private BadgeLevel badgeLevel;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate badgeDate;
 
     public DashboardResponseDto(String username, String email, Role role, VerificationStatus status){

--- a/src/main/java/com/veribadge/veribadge/dto/DashboardResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/DashboardResponseDto.java
@@ -1,0 +1,27 @@
+package com.veribadge.veribadge.dto;
+
+import com.veribadge.veribadge.domain.enums.BadgeLevel;
+import com.veribadge.veribadge.domain.enums.Role;
+import com.veribadge.veribadge.domain.enums.VerificationStatus;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+public class DashboardResponseDto {
+    private String username;
+    private String email;
+    private Role role;
+    private VerificationStatus status;
+
+    // 뱃지 발급받은 경우만
+    private BadgeLevel badgeLevel;
+    private LocalDate badgeDate;
+
+    public DashboardResponseDto(String username, String email, Role role, VerificationStatus status){
+        this.username = username;
+        this.email = email;
+        this.role = role;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/dto/DashboardResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/DashboardResponseDto.java
@@ -4,9 +4,11 @@ import com.veribadge.veribadge.domain.enums.BadgeLevel;
 import com.veribadge.veribadge.domain.enums.Role;
 import com.veribadge.veribadge.domain.enums.VerificationStatus;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDate;
 
+@Getter
 @AllArgsConstructor
 public class DashboardResponseDto {
     private String username;

--- a/src/main/java/com/veribadge/veribadge/dto/MyBadgeResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/MyBadgeResponseDto.java
@@ -1,0 +1,28 @@
+package com.veribadge.veribadge.dto;
+
+import com.veribadge.veribadge.domain.enums.BadgeLevel;
+import com.veribadge.veribadge.domain.enums.VerificationStatus;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+public class MyBadgeResponseDto {
+    private String username;
+    private String email;
+    private VerificationStatus status;
+
+    // 뱃지 발급받은 경우만
+    private BadgeLevel badgeLevel;
+    private LocalDate badgeDate;
+
+    // 연결 채널 있는 경우만
+    private String channelUrl;
+    private String badgeTag;
+
+    public MyBadgeResponseDto(String username, String email, VerificationStatus status){
+        this.username = username;
+        this.email = email;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/dto/MyBadgeResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/MyBadgeResponseDto.java
@@ -3,9 +3,11 @@ package com.veribadge.veribadge.dto;
 import com.veribadge.veribadge.domain.enums.BadgeLevel;
 import com.veribadge.veribadge.domain.enums.VerificationStatus;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDate;
 
+@Getter
 @AllArgsConstructor
 public class MyBadgeResponseDto {
     private String username;

--- a/src/main/java/com/veribadge/veribadge/dto/MyBadgeResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/MyBadgeResponseDto.java
@@ -1,5 +1,6 @@
 package com.veribadge.veribadge.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.veribadge.veribadge.domain.enums.BadgeLevel;
 import com.veribadge.veribadge.domain.enums.VerificationStatus;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,8 @@ public class MyBadgeResponseDto {
 
     // 뱃지 발급받은 경우만
     private BadgeLevel badgeLevel;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate badgeDate;
 
     // 연결 채널 있는 경우만

--- a/src/main/java/com/veribadge/veribadge/global/status/SuccessStatus.java
+++ b/src/main/java/com/veribadge/veribadge/global/status/SuccessStatus.java
@@ -17,7 +17,11 @@ public enum SuccessStatus {
     // Member
     MEMBER_CREATED(HttpStatus.CREATED, "SIGNUP 201", "회원가입 성공"),
     LOGIN_SUCCESS(HttpStatus.OK, "LOGIN 200", "로그인 성공"),
-    LOGOUT_SUCCESS(HttpStatus.OK, "LOGOUT 200", "로그아웃 성공");
+    LOGOUT_SUCCESS(HttpStatus.OK, "LOGOUT 200", "로그아웃 성공"),
+
+    // MyBadge
+    MY_BADGE_SUCCESS(HttpStatus.OK, "MYBADGE 200", "나의 뱃지 페이지 불러오기 성공"),
+    CHANNEL_CONNECTED(HttpStatus.OK, "MYBADGE 200", "유튜브 채널 연결 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/veribadge/veribadge/global/status/SuccessStatus.java
+++ b/src/main/java/com/veribadge/veribadge/global/status/SuccessStatus.java
@@ -11,6 +11,9 @@ public enum SuccessStatus {
     SUCCESS(HttpStatus.OK, "COMMON 200", "요청이 성공적으로 처리되었습니다."),
     CREATED(HttpStatus.CREATED, "COMMON 201", "리소스가 성공적으로 생성되었습니다."),
 
+    // Main
+    MAIN_SUCCESS(HttpStatus.OK, "MAIN 201", "메인페이지 불러오기 성공"),
+
     // Member
     MEMBER_CREATED(HttpStatus.CREATED, "SIGNUP 201", "회원가입 성공"),
     LOGIN_SUCCESS(HttpStatus.OK, "LOGIN 200", "로그인 성공"),

--- a/src/main/java/com/veribadge/veribadge/repository/MemberRepository.java
+++ b/src/main/java/com/veribadge/veribadge/repository/MemberRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUserId(Long userId);
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/veribadge/veribadge/service/MainService.java
+++ b/src/main/java/com/veribadge/veribadge/service/MainService.java
@@ -23,8 +23,8 @@ public class MainService {
     private final VerificationRepository verificationRepository;
     private final BadgeRepository badgeRepository;
 
-    public DashboardResponseDto getMyBadge() throws CustomException {
-        Member member = memberRepository.findByEmail("test1@example.com") // FIXME : 지금은 하드코딩, 로그인 구현 후 수정 예정
+    public DashboardResponseDto getMyBadge(Long userId) {
+        Member member = memberRepository.findByUserId(userId) // FIXME : 로그인 구현 후 수정 예정
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Optional<Verification> verification = verificationRepository.findByUserId(member);

--- a/src/main/java/com/veribadge/veribadge/service/MainService.java
+++ b/src/main/java/com/veribadge/veribadge/service/MainService.java
@@ -1,0 +1,61 @@
+package com.veribadge.veribadge.service;
+
+import com.veribadge.veribadge.domain.Badge;
+import com.veribadge.veribadge.domain.Member;
+import com.veribadge.veribadge.domain.Verification;
+import com.veribadge.veribadge.domain.enums.VerificationStatus;
+import com.veribadge.veribadge.dto.DashboardResponseDto;
+import com.veribadge.veribadge.exception.CustomException;
+import com.veribadge.veribadge.global.status.ErrorStatus;
+import com.veribadge.veribadge.repository.BadgeRepository;
+import com.veribadge.veribadge.repository.MemberRepository;
+import com.veribadge.veribadge.repository.VerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MainService {
+
+    private final MemberRepository memberRepository;
+    private final VerificationRepository verificationRepository;
+    private final BadgeRepository badgeRepository;
+
+    public DashboardResponseDto getMyBadge() throws CustomException {
+        Member member = memberRepository.findByEmail("test1@example.com") // FIXME : 지금은 하드코딩, 로그인 구현 후 수정 예정
+                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Optional<Verification> verification = verificationRepository.findByUserId(member);
+
+        if (verification.isEmpty()) { // 로그인만 되어있는 사용자 (제출X, 인증X)
+            return new DashboardResponseDto(
+                    member.getUsername(),
+                    member.getEmail(),
+                    member.getRole(),
+                    VerificationStatus.NOT_SUBMITTED
+            );
+        }
+
+        Optional<Badge> badge = badgeRepository.findByVerificationId(verification.get());
+
+        return badge.map(value ->
+                // 인증서 제출은 했지만 아직 인증 안된 사용자 (제출O, 인증O)
+                new DashboardResponseDto(
+                    member.getUsername(),
+                    member.getEmail(),
+                    member.getRole(),
+                    verification.get().getStatus(),
+                    value.getBadgeLevel(),
+                    value.getVerifiedDate()
+        )).orElseGet(() ->
+                // 인증서 제출은 했지만 아직 인증 안된 사용자 (제출O, 인증 아직 or 거절)
+                new DashboardResponseDto(
+                    member.getUsername(),
+                    member.getEmail(),
+                    member.getRole(),
+                    verification.get().getStatus()
+        ));
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
+++ b/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
@@ -23,8 +23,8 @@ public class MyBadgeService {
     private final VerificationRepository verificationRepository;
     private final BadgeRepository badgeRepository;
 
-    public MyBadgeResponseDto getMyBadge(){
-        Member member = memberRepository.findByEmail("test3@example.com") // FIXME : 지금은 하드코딩, 로그인 구현 후 수정 예정
+    public MyBadgeResponseDto getMyBadge(Long userId){
+        Member member = memberRepository.findByUserId(userId) // FIXME : 로그인 구현 후 수정 예정
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Optional<Verification> verification = verificationRepository.findByUserId(member);

--- a/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
+++ b/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
@@ -1,0 +1,60 @@
+package com.veribadge.veribadge.service;
+
+import com.veribadge.veribadge.domain.Badge;
+import com.veribadge.veribadge.domain.Member;
+import com.veribadge.veribadge.domain.Verification;
+import com.veribadge.veribadge.domain.enums.VerificationStatus;
+import com.veribadge.veribadge.dto.MyBadgeResponseDto;
+import com.veribadge.veribadge.exception.CustomException;
+import com.veribadge.veribadge.global.status.ErrorStatus;
+import com.veribadge.veribadge.repository.BadgeRepository;
+import com.veribadge.veribadge.repository.MemberRepository;
+import com.veribadge.veribadge.repository.VerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MyBadgeService {
+
+    private final MemberRepository memberRepository;
+    private final VerificationRepository verificationRepository;
+    private final BadgeRepository badgeRepository;
+
+    public MyBadgeResponseDto getMyBadge(){
+        Member member = memberRepository.findByEmail("test3@example.com") // FIXME : 지금은 하드코딩, 로그인 구현 후 수정 예정
+                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Optional<Verification> verification = verificationRepository.findByUserId(member);
+
+        if (verification.isEmpty()) { // 로그인만 되어있는 사용자 (제출X, 인증X)
+            return new MyBadgeResponseDto(
+                    member.getUsername(),
+                    member.getEmail(),
+                    VerificationStatus.NOT_SUBMITTED
+            );
+        }
+
+        Optional<Badge> badge = badgeRepository.findByVerificationId(verification.get());
+
+        return badge.map(value ->
+                // 인증서 제출은 했지만 아직 인증 안된 사용자 (제출O, 인증O) -> 채널 연결 O / X
+                new MyBadgeResponseDto(
+                        member.getUsername(),
+                        member.getEmail(),
+                        verification.get().getStatus(),
+                        value.getBadgeLevel(),
+                        value.getVerifiedDate(),
+                        badge.get().getChannelUrl(),
+                        badge.get().getVerifiedTag()
+                )).orElseGet(() ->
+                // 인증서 제출은 했지만 아직 인증 안된 사용자 (제출O, 인증 아직 or 거절)
+                new MyBadgeResponseDto(
+                        member.getUsername(),
+                        member.getEmail(),
+                        verification.get().getStatus()
+                ));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

swagger 설정 및 대시보드, 나의 뱃지 관리 페이지 get 구현

### 🎯 주요 변경 사항

- swagger 설정 (API 문서 자동화)
- 대시보드 페이지 get 구현
- 나의 뱃지 관리 페이지 get 구현


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

*swagger 버전 문제로 인해 스프링부트 버전 조절했습니다.