### PR TITLE
[REAFAOR] JWT오류 수정

### DIFF
--- a/src/main/java/com/veribadge/veribadge/config/SecurityConfig.java
+++ b/src/main/java/com/veribadge/veribadge/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -18,12 +19,13 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
                 .csrf(csrf -> csrf.disable())
-                // .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**",
@@ -31,7 +33,9 @@ public class SecurityConfig {
                                 "/v3/api-docs.yaml",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/auth/kakao/callback",
+                                "/oauth2/authorization/**",
+                                "/auth/**",
+                                "/auth/google/get-user-info",
                                 "/api/badge/verify",
                                 "/favicon.ico",
                                 "/css/**",

--- a/src/main/java/com/veribadge/veribadge/controller/AuthController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/AuthController.java
@@ -40,33 +40,11 @@ import java.util.Map;
 @Slf4j
 public class AuthController {
     private final JwtKakaoProvider jwtKakaoProvider;
-    private final KakaoService kakaoService;
+    //private final KakaoService kakaoService;
     private final MemberRepository memberRepository;
     private final GoogleService googleService;
     private final OAuth2AuthorizedClientService authorizedClientService;
 
-    @GetMapping("/kakao/callback")
-    public Response<LoginResponseDto> kakaoCallback(@RequestParam String code) {
-
-        String tokenJsonResponse = kakaoService.getAccessToken(code);
-        String accessToken = kakaoService.getAccessTokenOnly(tokenJsonResponse);
-        log.info(">>>>> ACCESS TOKEN: {} <<<<<", accessToken);
-        KakaoUserInfoDto userInfo = kakaoService.getUserInfo(accessToken);
-        Long kakaoId = userInfo.getId();
-
-        Member member = memberRepository.findByKakaoId(kakaoId)
-                .orElseGet(() -> memberRepository.save(Member.builder()
-                        .kakaoId(kakaoId)
-                        .username(userInfo.getKakaoAccount().getName())
-                        .role(Role.USER)
-                        .build()));
-
-        String jwt = jwtKakaoProvider.generateToken(member.getUserId());
-        forceLogin(member);
-
-        LoginResponseDto responseDto = new LoginResponseDto(member,jwt);
-        return Response.success(SuccessStatus.LOGIN_SUCCESS, responseDto);
-    }
 
     private void forceLogin(Member member) {
         UserDetails userDetails = new User(member.getUserId().toString(), "", Collections.emptyList());

--- a/src/main/java/com/veribadge/veribadge/controller/ConnectController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/ConnectController.java
@@ -1,0 +1,37 @@
+package com.veribadge.veribadge.controller;
+
+import com.veribadge.veribadge.domain.Member;
+import com.veribadge.veribadge.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import java.io.IOException;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ConnectController {
+
+    private final AuthService authService; // 현재 로그인된 사용자를 알려주는 서비스
+
+    /**
+     * 구글 계정 연동을 시작하는 API입니다.
+     * 이 API는 반드시 우리 서비스의 JWT(Access Token)를 헤더에 포함하여 호출해야 합니다.
+     */
+    @GetMapping("/auth/connect/google")
+    public void connectGoogle(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // 1. 현재 우리 서비스에 로그인된 사용자가 누구인지 확인합니다. (JWT 기반)
+        Member currentMember = authService.getCurrentUser();
+        var session = request.getSession(true);
+        log.info("connectGoogle JSESSIONID={}", session.getId());
+
+        // 2. 구글 인증하러 가기 전에, 이 사용자의 ID를 세션(임시 메모장)에 기록합니다.
+        request.getSession().setAttribute("userIdToConnect", currentMember.getUserId());
+
+        // 3. 이제 진짜 스프링 시큐리티의 구글 인증 페이지로 사용자를 보냅니다.
+        response.sendRedirect("/oauth2/authorization/google");
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/veribadge/veribadge/handler/CustomOAuth2SuccessHandler.java
@@ -1,8 +1,13 @@
 package com.veribadge.veribadge.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.veribadge.veribadge.domain.Member;
+import com.veribadge.veribadge.domain.enums.Role;
+import com.veribadge.veribadge.dto.LoginResponseDto;
 import com.veribadge.veribadge.exception.CustomException;
+import com.veribadge.veribadge.exception.Response;
 import com.veribadge.veribadge.global.status.ErrorStatus;
+import com.veribadge.veribadge.global.status.SuccessStatus;
 import com.veribadge.veribadge.jwt.JwtGoogleProvider;
 import com.veribadge.veribadge.jwt.JwtKakaoProvider;
 import com.veribadge.veribadge.repository.MemberRepository;
@@ -11,10 +16,12 @@ import com.veribadge.veribadge.service.MyBadgeService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -24,6 +31,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtGoogleProvider jwtGoogleProvider;
@@ -32,7 +40,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
     private final MyBadgeService myBadgeService;
     private final OAuth2AuthorizedClientService authorizedClientService;
     private final MemberRepository memberRepository;
-
+    private final ObjectMapper objectMapper;
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
@@ -43,50 +51,95 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         // 1. provider 이름(registrationId) 가져오기
         String registrationId = oauthToken.getAuthorizedClientRegistrationId();
 
-        String redirectUrl;
+        Response<?> finalResponse;
+        //String redirectUrl;
         String jwt;
 
-        // 2. provider에 따라 분기 처리
-        if ("google".equals(registrationId)) {
-            // --- Google 로그인 로직 ---
-            OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
-                    oauthToken.getAuthorizedClientRegistrationId(),
-                    oauthToken.getName()
-            );
+        Member finalMember; // 최종적으로 로그인된 회원을 담을 변수
 
+               // 2. provider에 따라 분기 처리
+        if ("google".equals(registrationId)) {
+            log.info("Google 계정 연동을 시작");
+
+            // 1. 세션(임시 메모장)에서 '누가' 연동을 시작했는지 사용자 ID를 꺼냅니다.
+            Long currentUserId = (Long) request.getSession().getAttribute("userIdToConnect");
+            log.info("Google link target userId={}", currentUserId);
+            log.info("SuccessHandler JSESSIONID={}",
+                    request.getSession(false) != null ? request.getSession(false).getId() : "null");
+            if (currentUserId == null) {
+                throw new CustomException(ErrorStatus.UNAUTHORIZED); // 비정상적인 접근
+            }
+            request.getSession().removeAttribute("userIdToConnect"); // 사용 후 메모는 바로 삭제
+
+            Member currentMember = memberRepository.findById(currentUserId)
+                    .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+
+
+            // --- Google 로그인 로직 ---
+            OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(registrationId, authentication.getName());
             String accessToken = client.getAccessToken().getTokenValue();
 
             Map<String, Object> userInfo = googleService.getUserInfo(accessToken);
             String email = (String) userInfo.get("email");
             String channelUrl = (String) userInfo.get("channelLink");
 
-            myBadgeService.connectChannel(channelUrl, email);
+            myBadgeService.connectChannel(channelUrl, email, currentMember);
 
-            jwt = jwtGoogleProvider.generateToken(email);
+            finalResponse = Response.success(SuccessStatus.CHANNEL_CONNECTED, Map.of("message", "구글 계정이 성공적으로 연동되었습니다."));
 
-            redirectUrl = "https://veribadge.vercel.app/my-badges";
+            //finalResponse = Response.success(SuccessStatus.CHANNEL_CONNECTED, Map.of("accessToken", accessToken));
+            //jwt = jwtGoogleProvider.generateToken(email);
+            //redirectUrl = "https://veribadge.vercel.app/my-badges";
 
         } else if ("kakao".equals(registrationId)) {
             // --- Kakao 로그인 로직 ---
+            log.info("Kakao 로그인");
+            OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
 
-            Long userId = Long.valueOf(authentication.getName());
-            Member member = memberRepository.findById(userId)
-                    .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+            Long kakaoId = Long.valueOf(oAuth2User.getName());
+            String username = (String) kakaoAccount.get("name");
 
+            Member member = memberRepository.findByKakaoId(kakaoId)
+                    .orElseGet(() -> {
+                        log.info("신규 카카오 회원입니다. 이름 '{}'(으)로 자동 가입합니다.", username);
+                        return memberRepository.save(Member.builder()
+                                .kakaoId(kakaoId)
+                                .username(username)
+                                .role(Role.USER)
+                                .build());
+                    });
 
             jwt = jwtKakaoProvider.generateToken(member.getUserId());
-
-            redirectUrl = "https://veribadge.vercel.app/";
+            LoginResponseDto loginResponseDto = new LoginResponseDto(member, jwt);
+            finalResponse = Response.success(SuccessStatus.LOGIN_SUCCESS, loginResponseDto);
+            //redirectUrl = "https://veribadge.vercel.app/";
         } else {
             // 지원하지 않는 provider인 경우 예외 처리
-            throw new CustomException(ErrorStatus.OAUTH_PROVIDER_NOT_SUPPORTED);
+            throw new CustomException(ErrorStatus.BAD_REQUEST);
         }
 
         // 3. --- 공통 로직: JWT 발급 및 리다이렉트 ---
+        /*
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
                 .queryParam("token", jwt)
                 .build().toUriString();
 
         response.sendRedirect(targetUrl);
+         */
+
+
+
+
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        String result = objectMapper.writeValueAsString(finalResponse);
+        response.getWriter().write(result);
+        // ------------------------------------
+
+
     }
 }

--- a/src/main/java/com/veribadge/veribadge/jwt/JwtKakaoProvider.java
+++ b/src/main/java/com/veribadge/veribadge/jwt/JwtKakaoProvider.java
@@ -2,16 +2,25 @@ package com.veribadge.veribadge.jwt;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
 import java.security.Key;
 import java.util.Date;
 
 @Component
 public class JwtKakaoProvider {
 
-    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256); // Todo : 고정키 사용
+    private final SecretKey key;
+
+    // 생성자를 통해 application-dev.yml의 jwt.secret 값을 주입받아 '마스터 키'를 생성합니다.
+    public JwtKakaoProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
 
     public String generateToken(Long userId) {
         long now = System.currentTimeMillis();
@@ -21,7 +30,7 @@ public class JwtKakaoProvider {
                 .setSubject(String.valueOf(userId))
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(now + validity))
-                .signWith(key)
+                .signWith(key) // 이제 고정된 마스터 키로 서명합니다.
                 .compact();
     }
 

--- a/src/main/java/com/veribadge/veribadge/mock/VerificationInitializer.java
+++ b/src/main/java/com/veribadge/veribadge/mock/VerificationInitializer.java
@@ -67,5 +67,9 @@ public class VerificationInitializer implements CommandLineRunner {
         } else {
             log.info("모든 테스트 인증이 이미 존재합니다.");
         }
+
+
     }
+
+
 }

--- a/src/main/java/com/veribadge/veribadge/service/AuthService.java
+++ b/src/main/java/com/veribadge/veribadge/service/AuthService.java
@@ -23,12 +23,12 @@ public class AuthService {
         // 1. SecurityContextHolder에서 인증 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new CustomException(ErrorStatus.INVALID_TOKEN);
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getName())) {
+            throw new CustomException(ErrorStatus.UNAUTHORIZED);
         }
 
-        // 2. JWT의 subject(email)을 꺼내기
-        Long userId = Long.valueOf(authentication.getName());
+
+        Long userId = Long.parseLong(authentication.getName());
 
         // 3. 우리 DB에서 Member 조회
         return memberRepository.findById(userId)

--- a/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
+++ b/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
@@ -62,9 +62,9 @@ public class MyBadgeService {
 
     @Transactional
     public void connectChannel(String channelUrl, String email){
-        Member member = authService.getCurrentUser();
-//        Member member = memberRepository.findByUserId(3L)
-//                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+        // Member member = authService.getCurrentUser();
+        Member member = memberRepository.findByUserId(3L)
+                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Verification verification = verificationRepository.findByUserId(member)
                 .orElseThrow(() -> new CustomException(ErrorStatus.VERIFICATION_NOT_FOUND));

--- a/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
+++ b/src/main/java/com/veribadge/veribadge/service/MyBadgeService.java
@@ -29,8 +29,6 @@ public class MyBadgeService {
 
     public MyBadgeResponseDto getMyBadge(){
         Member member = authService.getCurrentUser();
-//        Member member = memberRepository.findByUserId(userId)
-//                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Optional<Verification> verification = verificationRepository.findByUserId(member);
 
@@ -60,12 +58,20 @@ public class MyBadgeService {
                 ));
     }
 
-    @Transactional
-    public void connectChannel(String channelUrl, String email){
-        // Member member = authService.getCurrentUser();
-        Member member = memberRepository.findByUserId(3L)
-                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
+    public void connectChannel(String channelUrl, String email) {
+        // 현재 로그인 사용자 기준으로 연결
+        Member member = authService.getCurrentUser();
+        connectChannelForMember(member, channelUrl, email);
+    }
+
+    @Transactional
+    public void connectChannel(String channelUrl, String email, Member member) {
+        // 외부(예: OAuth SuccessHandler)에서 특정 member를 넘겨줄 때 사용
+        connectChannelForMember(member, channelUrl, email);
+    }
+
+    private void connectChannelForMember(Member member, String channelUrl, String email) {
         Verification verification = verificationRepository.findByUserId(member)
                 .orElseThrow(() -> new CustomException(ErrorStatus.VERIFICATION_NOT_FOUND));
 
@@ -74,10 +80,8 @@ public class MyBadgeService {
 
         BadgeLevel badgeLevel = badge.getBadgeLevel();
 
-        // Todo : 이미 채널 연결되어있으면 에러처리 필요
-
+        // 태그 중복 방지
         String badgeTag;
-
         do {
             badgeTag = switch (badgeLevel) {
                 case SILVER -> "@veri-silver-" + RandomStringGenerator();
@@ -89,7 +93,6 @@ public class MyBadgeService {
         } while (badgeRepository.existsByVerifiedTag(badgeTag));
 
         badge.connect(channelUrl, badgeTag, email);
-
         badgeRepository.save(badge);
     }
 

--- a/src/main/java/com/veribadge/veribadge/service/social/KakaoService.java
+++ b/src/main/java/com/veribadge/veribadge/service/social/KakaoService.java
@@ -17,7 +17,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-@Service
+//@Service
 @Slf4j
 public class KakaoService {
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,7 +17,20 @@ spring:
               - email
               - profile
               - https://www.googleapis.com/auth/youtube.readonly
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-name: kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - name
+            provider: kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  redirect_uri: https://two025-seasonthon-team-60-be.onrender.com/auth/kakao/callback
+
+


### PR DESCRIPTION
## 📝 작업 내용
JWT 토큰 따로 받는거 하나로 합쳤어요 
기존 파라미터를 그대로 받는 방식 말고 url로 연결 할 수 있도록 수정 했습니다. 


### 🎯 주요 변경 사항

- 카카오 로그인 → JWT 발급 정상
- 구글 연동 → 동일 세션에서 성공적으로 OAuth 플로우 수행


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
현재 로그인 하게 되면 user_id가 4번째에 있는데 테스트 데이터는 user_id 4가 없어서 아마도 구글 로그인 하시면 정보 없다고 에러날거에요 
로직은 잘 작동 될거에요..!! 확인 부탁드립니다.

테스트 하는 방법
http://localhost:8080/oauth2/authorization/kakao 로그인해서 jwt 토큰 발급
f12눌러서 consol
const JWT = '[여기에_네_JWT_붙여넣기]';

fetch('/auth/connect/google', {
  method: 'GET',
  headers: { Authorization: 'Bearer ' + JWT },
  credentials: 'include'
})
.finally(() => {
  location.href = '/oauth2/authorization/google';
});

