### PR TITLE
[FEAT] 소득증명서 업로드 API 구현

### DIFF
--- a/src/main/java/com/veribadge/veribadge/controller/VerificationController.java
+++ b/src/main/java/com/veribadge/veribadge/controller/VerificationController.java
@@ -1,0 +1,58 @@
+package com.veribadge.veribadge.controller;
+
+import com.veribadge.veribadge.dto.UploadVerificationResponseDto;
+import com.veribadge.veribadge.exception.CustomException;
+import com.veribadge.veribadge.exception.Response;
+import com.veribadge.veribadge.global.status.ErrorStatus;
+import com.veribadge.veribadge.global.status.SuccessStatus;
+import com.veribadge.veribadge.service.VerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/certificates")
+public class VerificationController {
+
+    private final VerificationService verificationService;
+
+    @PostMapping(
+            value = "/income/upload",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<Response<UploadVerificationResponseDto>> uploadIncomeCertificate(
+            @RequestParam("file") MultipartFile file,
+            Authentication authentication) {
+
+        Long userId = Long.valueOf(authentication.getName());
+
+        validateFile(file);
+
+        UploadVerificationResponseDto body =
+                verificationService.processIncomeCertificateUpload(file, userId);
+
+        return ResponseEntity.ok(Response.success(SuccessStatus.VERIFICATION_SUBMITTED, body));
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorStatus.FILE_EMPTY);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null ||
+                !(contentType.equals("image/png")
+                        || contentType.equals("image/jpeg")
+                        || contentType.equals("image/jpg"))) {
+            throw new CustomException(ErrorStatus.FILE_TYPE_NOT_SUPPORTED);
+        }
+        long maxSize = 10 * 1024 * 1024; // 10MB
+        if (file.getSize() > maxSize) {
+            throw new CustomException(ErrorStatus.FILE_SIZE_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/domain/Verification.java
+++ b/src/main/java/com/veribadge/veribadge/domain/Verification.java
@@ -16,11 +16,12 @@ public class Verification {
     @Column(name = "VERIFICATION_ID")
     private Long verificationId;
 
-    @OneToOne
+    @OneToOne//추후 파일 업로드 재요청 들어오면 바꿔야 할 수 있음
     @JoinColumn(name = "USER_ID")
     private Member userId;
 
-    @Column(nullable = false)
+    // 파일 저장 안 하면 null 가능하도록 (임시 URL/외부 URL 들어갈 수 있게)
+    @Column(nullable = true)
     private String certificateUrl;
 
     @Column(nullable = false)
@@ -34,8 +35,16 @@ public class Verification {
 
     private String description;
 
-    public Verification(Member userId, String certificateUrl){
+    @Column(nullable = false, unique = true, length = 64)
+    private String fileId;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    public Verification(Member userId, String fileId, String fileName, String certificateUrl){
         this.userId = userId;
+        this.fileId = fileId;
+        this.fileName = fileName;
         this.certificateUrl = certificateUrl;
         this.submittedDate = LocalDateTime.now();
         this.status = VerificationStatus.SUBMITTED;

--- a/src/main/java/com/veribadge/veribadge/dto/UploadVerificationResponseDto.java
+++ b/src/main/java/com/veribadge/veribadge/dto/UploadVerificationResponseDto.java
@@ -1,0 +1,20 @@
+package com.veribadge.veribadge.dto;
+
+import com.veribadge.veribadge.domain.enums.VerificationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "파일 업로드 응답 DTO")
+public class UploadVerificationResponseDto {
+
+    private String fileName;
+    private String fileId;
+    private VerificationStatus status;
+
+    public static UploadVerificationResponseDto of(String fileName, String fileId, VerificationStatus status) {
+        return new UploadVerificationResponseDto(fileName, fileId, status);
+    }
+}

--- a/src/main/java/com/veribadge/veribadge/global/status/ErrorStatus.java
+++ b/src/main/java/com/veribadge/veribadge/global/status/ErrorStatus.java
@@ -27,7 +27,14 @@ public enum ErrorStatus {
 
     // Verification
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VERI 404", "인증을 찾을 수 없습니다."),
-    BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "VERI 404", "뱃지를 찾을 수 없습니다.");
+    BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "VERI 404", "뱃지를 찾을 수 없습니다."),
+
+    // File Upload
+    FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE 400", "파일이 비어있습니다."),
+    FILE_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FILE 400", "지원하지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE 400", "파일 크기가 너무 큽니다."),
+    VERIFICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "VERI 409", "이미 제출된 인증이 있습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON 500", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/veribadge/veribadge/global/status/SuccessStatus.java
+++ b/src/main/java/com/veribadge/veribadge/global/status/SuccessStatus.java
@@ -25,7 +25,9 @@ public enum SuccessStatus {
 
     // MyBadge
     MY_BADGE_SUCCESS(HttpStatus.OK, "MYBADGE 200", "나의 뱃지 페이지 불러오기 성공"),
-    CHANNEL_CONNECTED(HttpStatus.OK, "MYBADGE 200", "유튜브 채널 연결 성공");
+    CHANNEL_CONNECTED(HttpStatus.OK, "MYBADGE 200", "유튜브 채널 연결 성공"),
+
+    VERIFICATION_SUBMITTED(HttpStatus.OK, "COMMON 200", "파일 제출이 완료되었습니다. 검토가 시작됩니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/veribadge/veribadge/mock/VerificationInitializer.java
+++ b/src/main/java/com/veribadge/veribadge/mock/VerificationInitializer.java
@@ -2,7 +2,6 @@ package com.veribadge.veribadge.mock;
 
 import com.veribadge.veribadge.domain.Member;
 import com.veribadge.veribadge.domain.Verification;
-import com.veribadge.veribadge.domain.enums.VerificationStatus;
 import com.veribadge.veribadge.exception.CustomException;
 import com.veribadge.veribadge.global.status.ErrorStatus;
 import com.veribadge.veribadge.repository.MemberRepository;
@@ -13,9 +12,9 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -27,38 +26,50 @@ public class VerificationInitializer implements CommandLineRunner {
     private final VerificationRepository verificationRepository;
 
     @Override
-    public void run(String... args){
+    public void run(String... args) {
         log.info("테스트 인증 데이터 생성");
 
         List<Verification> verificationsToSave = new ArrayList<>();
 
-        // 1. just signed up
-
-        // 2. submit certificate
-        String testEmail2 = "test2@example.com";
+        // 2. submit certificate (userId = 2)
         Member member2 = memberRepository.findByUserId(2L)
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
+        // @OneToOne 이므로 한 유저당 1건만 허용 → 이미 있으면 생성 X
         if (verificationRepository.findByUserId(member2).isEmpty()) {
-            Verification verification2 = new Verification(
+            String fileId2 = "file_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+            String fileName2 = "income_certificate_2.png"; // 목업 파일명
+            String certificateUrl2 = null; // 파일 저장 안 하므로 null 또는 "temp://" 사용 가능
+
+            Verification v2 = new Verification(
                     member2,
-                    "certificate url 2"
-            ); verificationsToSave.add(verification2);
+                    fileId2,
+                    fileName2,
+                    certificateUrl2
+            );
+            verificationsToSave.add(v2);
         } else {
-            log.info("{} 인증은 이미 존재합니다.", testEmail2);
+            log.info("userId=2 인증은 이미 존재합니다.");
         }
 
-        // 3. get verifiedTag
-        String testEmail3 = "test3@example.com";
+        // 3. get verifiedTag (userId = 3)
         Member member3 = memberRepository.findByUserId(3L)
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+
         if (verificationRepository.findByUserId(member3).isEmpty()) {
-            Verification verification3 = new Verification(
+            String fileId3 = "file_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+            String fileName3 = "income_certificate_3.jpg";
+            String certificateUrl3 = null;
+
+            Verification v3 = new Verification(
                     member3,
-                    "certificate url 3"
-            ); verificationsToSave.add(verification3);
+                    fileId3,
+                    fileName3,
+                    certificateUrl3
+            );
+            verificationsToSave.add(v3);
         } else {
-            log.info("{} 인증은 이미 존재합니다.", testEmail3);
+            log.info("userId=3 인증은 이미 존재합니다.");
         }
 
         if (!verificationsToSave.isEmpty()) {
@@ -67,9 +78,5 @@ public class VerificationInitializer implements CommandLineRunner {
         } else {
             log.info("모든 테스트 인증이 이미 존재합니다.");
         }
-
-
     }
-
-
 }

--- a/src/main/java/com/veribadge/veribadge/service/VerificationService.java
+++ b/src/main/java/com/veribadge/veribadge/service/VerificationService.java
@@ -1,0 +1,61 @@
+package com.veribadge.veribadge.service;
+
+import com.veribadge.veribadge.domain.Member;
+import com.veribadge.veribadge.domain.Verification;
+import com.veribadge.veribadge.domain.enums.VerificationStatus;
+import com.veribadge.veribadge.dto.UploadVerificationResponseDto;
+import com.veribadge.veribadge.exception.CustomException;
+import com.veribadge.veribadge.global.status.ErrorStatus;
+import com.veribadge.veribadge.repository.MemberRepository;
+import com.veribadge.veribadge.repository.VerificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+    private final MemberRepository memberRepository;
+    private final VerificationRepository verificationRepository;
+
+    @Transactional
+    public UploadVerificationResponseDto processIncomeCertificateUpload(MultipartFile file, Long userId) {
+        // 1) 사용자
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 2) 유효성 (이미지 전용)
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorStatus.FILE_EMPTY);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null ||
+                !(contentType.equals("image/png")
+                        || contentType.equals("image/jpeg")
+                        || contentType.equals("image/jpg"))) {
+            throw new CustomException(ErrorStatus.FILE_TYPE_NOT_SUPPORTED);
+        }
+        long maxSize = 10 * 1024 * 1024;
+        if (file.getSize() > maxSize) {
+            throw new CustomException(ErrorStatus.FILE_SIZE_EXCEEDED);
+        }
+
+        // 3) 파일은 저장하지 않음 → 식별자/파일명만
+        String fileId = "file_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+        String fileName = (file.getOriginalFilename() != null) ? file.getOriginalFilename() : "income_certificate.png";
+
+        // 4) certificateUrl은 저장 안 하므로 null 또는 임시값
+        String certificateUrl = null; // or: "temp://" + fileId + "/" + fileName
+
+        // 5) 엔티티 저장
+        Verification verification = new Verification(member, fileId, fileName, certificateUrl);
+        verificationRepository.save(verification);
+
+        // 6) 응답
+        return UploadVerificationResponseDto.of(fileName, fileId, VerificationStatus.SUBMITTED);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB       # 파일 하나의 최대 크기
+      max-request-size: 10MB    # 요청 전체 크기 (파일 여러 개 포함 시)


### PR DESCRIPTION
## 📝 작업 내용

multipart/form-data 형식으로 이미지 업로드 가능

실제 파일은 저장하지 않고, 메타데이터(fileId, fileName, status)만 DB에 저장(관리자 페이지 생성시 변경)

업로드 성공 시 상태값을 SUBMITTED로 반환

### 🎯 주요 변경 사항

- Verification 엔티티 수정
- processIncomeCertificateUpload 메서드 구현 (메타데이터 저장 및 DTO 반환)
- POST /certificates/income/upload 엔드포인트 추가
- application.yml
   multipart 업로드 제한 (10MB) 설정
- 테스트용 데이터 초기화(VerificationInitializer) 수정


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
추후 재업로드(재요청) 지원을 위해 @OneToOne → @ManyToOne으로 관계를 바꿔야 할 수도 있음
프론트에서 Firebase/S3 같은 스토리지 URL을 넘겨줄 경우 certificateUrl에 저장하면 확장 가능
